### PR TITLE
Scalar types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.xml]
+max_line_length = 9999999

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>querybean-generator</artifactId>
-      <version>12.4.1</version>
+      <version>12.4.2-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/io/ebean/typequery/PScalar.java
+++ b/src/main/java/io/ebean/typequery/PScalar.java
@@ -1,0 +1,29 @@
+package io.ebean.typequery;
+
+/**
+ * Property for classes that are serialized/deserialized by
+ * ScalarType/AttributeConverter.
+ *
+ * @param <R> the root query bean type
+ * @param <D> the scalar type
+ */
+public class PScalar<R, D> extends PBaseValueEqual<R, D> {
+
+  /**
+   * Construct with a property name and root instance.
+   *
+   * @param name property name
+   * @param root the root query bean instance
+   */
+  public PScalar(String name, R root) {
+    super(name , root);
+  }
+
+  /**
+   * Construct with additional path prefix.
+   */
+  public PScalar(String name, R root, String prefix) {
+    super(name, root, prefix);
+  }
+
+}

--- a/src/main/java/io/ebean/typequery/PScalarComparable.java
+++ b/src/main/java/io/ebean/typequery/PScalarComparable.java
@@ -1,0 +1,30 @@
+package io.ebean.typequery;
+
+/**
+ * Property for classes that are serialized/deserialized by
+ * ScalarType/AttributeConverter. If the classes are comparable,
+ * it is assumed that the database can compare the serialized values too.
+ *
+ * @param <R> the root query bean type
+ * @param <D> the scalar type
+ */
+public class PScalarComparable<R, D extends Comparable<D>> extends PBaseCompareable<R, D> {
+
+  /**
+   * Construct with a property name and root instance.
+   *
+   * @param name property name
+   * @param root the root query bean instance
+   */
+  public PScalarComparable(String name, R root) {
+    super(name , root);
+  }
+
+  /**
+   * Construct with additional path prefix.
+   */
+  public PScalarComparable(String name, R root, String prefix) {
+    super(name, root, prefix);
+  }
+
+}

--- a/src/test/java/org/example/domain/Customer.java
+++ b/src/test/java/org/example/domain/Customer.java
@@ -5,6 +5,7 @@ import io.ebean.annotation.EnumValue;
 import io.ebean.types.Inet;
 import org.example.domain.finder.CustomerFinder;
 import org.example.domain.otherpackage.PhoneNumber;
+import org.example.domain.otherpackage.ValidEmail;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -45,6 +46,8 @@ public class Customer extends BaseModel {
   boolean inactive;
 
   PhoneNumber phoneNumber;
+
+  ValidEmail email;
 
   @Column(length = 100)
   String name;
@@ -143,6 +146,14 @@ public class Customer extends BaseModel {
 
   public void setPhoneNumber(final PhoneNumber phoneNumber) {
     this.phoneNumber = phoneNumber;
+  }
+
+  public ValidEmail getEmail() {
+    return email;
+  }
+
+  public void setEmail(final ValidEmail email) {
+    this.email = email;
   }
 
   /**

--- a/src/test/java/org/example/domain/Customer.java
+++ b/src/test/java/org/example/domain/Customer.java
@@ -4,6 +4,7 @@ import io.ebean.annotation.Cache;
 import io.ebean.annotation.EnumValue;
 import io.ebean.types.Inet;
 import org.example.domain.finder.CustomerFinder;
+import org.example.domain.otherpackage.PhoneNumber;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -42,6 +43,8 @@ public class Customer extends BaseModel {
   Status status;
 
   boolean inactive;
+
+  PhoneNumber phoneNumber;
 
   @Column(length = 100)
   String name;
@@ -132,6 +135,14 @@ public class Customer extends BaseModel {
 
   public void setContacts(List<Contact> contacts) {
     this.contacts = contacts;
+  }
+
+  public PhoneNumber getPhoneNumber() {
+    return phoneNumber;
+  }
+
+  public void setPhoneNumber(final PhoneNumber phoneNumber) {
+    this.phoneNumber = phoneNumber;
   }
 
   /**

--- a/src/test/java/org/example/domain/otherpackage/Email.java
+++ b/src/test/java/org/example/domain/otherpackage/Email.java
@@ -1,0 +1,4 @@
+package org.example.domain.otherpackage;
+
+public interface Email<T> extends Comparable<T> {
+}

--- a/src/test/java/org/example/domain/otherpackage/PhoneAttributeConverter.java
+++ b/src/test/java/org/example/domain/otherpackage/PhoneAttributeConverter.java
@@ -1,0 +1,17 @@
+package org.example.domain.otherpackage;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class PhoneAttributeConverter implements AttributeConverter<PhoneNumber, String> {
+  @Override
+  public String convertToDatabaseColumn(final PhoneNumber attribute) {
+    return attribute.getMsisdn();
+  }
+
+  @Override
+  public PhoneNumber convertToEntityAttribute(final String dbData) {
+    return new PhoneNumber(dbData);
+  }
+}

--- a/src/test/java/org/example/domain/otherpackage/PhoneNumber.java
+++ b/src/test/java/org/example/domain/otherpackage/PhoneNumber.java
@@ -1,0 +1,13 @@
+package org.example.domain.otherpackage;
+
+public class PhoneNumber {
+  private final String msisdn;
+
+  public PhoneNumber(final String msisdn) {
+    this.msisdn = msisdn;
+  }
+
+  public String getMsisdn() {
+    return msisdn;
+  }
+}

--- a/src/test/java/org/example/domain/otherpackage/ValidEmail.java
+++ b/src/test/java/org/example/domain/otherpackage/ValidEmail.java
@@ -1,0 +1,18 @@
+package org.example.domain.otherpackage;
+
+public class ValidEmail implements Email<ValidEmail> {
+  private final String emailAddress;
+
+  public ValidEmail(final String emailAddress) {
+    this.emailAddress = emailAddress;
+  }
+
+  public String getEmailAddress() {
+    return emailAddress;
+  }
+
+  @Override
+  public int compareTo(final ValidEmail o) {
+    return emailAddress.compareTo(o.emailAddress);
+  }
+}

--- a/src/test/java/org/example/domain/otherpackage/ValidEmailAttributeConverter.java
+++ b/src/test/java/org/example/domain/otherpackage/ValidEmailAttributeConverter.java
@@ -1,0 +1,17 @@
+package org.example.domain.otherpackage;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class ValidEmailAttributeConverter implements AttributeConverter<ValidEmail, String> {
+  @Override
+  public String convertToDatabaseColumn(final ValidEmail attribute) {
+    return attribute.getEmailAddress();
+  }
+
+  @Override
+  public ValidEmail convertToEntityAttribute(final String dbData) {
+    return new ValidEmail(dbData);
+  }
+}

--- a/src/test/java/org/querytest/QCustomerTest.java
+++ b/src/test/java/org/querytest/QCustomerTest.java
@@ -15,6 +15,7 @@ import org.example.domain.Animal;
 import org.example.domain.Country;
 import org.example.domain.Customer;
 import org.example.domain.otherpackage.PhoneNumber;
+import org.example.domain.otherpackage.ValidEmail;
 import org.example.domain.query.QAnimal;
 import org.example.domain.query.QContact;
 import org.example.domain.query.QCustomer;
@@ -782,6 +783,31 @@ public class QCustomerTest {
       .name.eq(testName.getMethodName())
       .phoneNumber.eq(new PhoneNumber("+18005555555"))
       .findOne()).isNotNull();
+  }
+
+
+  @Test
+  public void testFetchByComparableScalarValue() {
+    Customer cust = new Customer();
+    cust.setName(testName.getMethodName());
+    cust.setEmail(new ValidEmail("foo2@example.org"));
+    cust.save();
+    assertThat(new QCustomer()
+      .name.eq(testName.getMethodName())
+      .email.eq(new ValidEmail("foo2@example.org"))
+      .findOne()).isNotNull();
+    assertThat(new QCustomer()
+      .name.eq(testName.getMethodName())
+      .email.gt(new ValidEmail("foo2@example.org"))
+            .findOne()).isNull();
+    assertThat(new QCustomer()
+      .name.eq(testName.getMethodName())
+      .email.gt(new ValidEmail("foo1@example.org"))
+            .findOne()).isNotNull();
+    assertThat(new QCustomer()
+      .name.eq(testName.getMethodName())
+      .email.greaterOrEqualTo(new ValidEmail("foo2@example.org"))
+            .findOne()).isNotNull();
   }
 
 

--- a/src/test/java/org/querytest/QCustomerTest.java
+++ b/src/test/java/org/querytest/QCustomerTest.java
@@ -14,12 +14,15 @@ import org.example.domain.Address;
 import org.example.domain.Animal;
 import org.example.domain.Country;
 import org.example.domain.Customer;
+import org.example.domain.otherpackage.PhoneNumber;
 import org.example.domain.query.QAnimal;
 import org.example.domain.query.QContact;
 import org.example.domain.query.QCustomer;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -43,6 +46,9 @@ import static org.example.domain.query.QContact.Alias.lastName;
 import static org.example.domain.query.QCustomer.Alias.billingAddress;
 
 public class QCustomerTest {
+
+  @Rule
+  public final TestName testName = new TestName();
 
   @Test
   public void findWithTransaction() {
@@ -763,6 +769,19 @@ public class QCustomerTest {
       .findSingleAttribute();
 
     assertThat(maxDate).isNotNull();
+  }
+
+
+  @Test
+  public void testFetchByScalarValue() {
+    Customer cust = new Customer();
+    cust.setName(testName.getMethodName());
+    cust.setPhoneNumber(new PhoneNumber("+18005555555"));
+    cust.save();
+    assertThat(new QCustomer()
+      .name.eq(testName.getMethodName())
+      .phoneNumber.eq(new PhoneNumber("+18005555555"))
+      .findOne()).isNotNull();
   }
 
 


### PR DESCRIPTION
Solution B for https://github.com/ebean-orm/ebean-querybean/issues/74

This just assumes that every field that is supposed to be serialized into the database, can also be queried.

In addition, those fields whose type implements `Comparable` will also be assumed to be comparable by the database.